### PR TITLE
Reduce size of MakeYourChoice.exe from 147 MB to 66 MB.

### DIFF
--- a/win/MakeYourChoice.csproj
+++ b/win/MakeYourChoice.csproj
@@ -20,6 +20,9 @@
         <!-- auto-elevation and icon  -->
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <ApplicationIcon>icon.ico</ApplicationIcon>
+
+        <!-- size optimization -->
+        <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The 147 MB binary is rather large for an app that edits a file.

Compression seems like a pretty easy win to slash the binary size. Startup time difference seems negligible.

I also explored trimming, but there's too much reflection. Even [overriding the build errors](https://stackoverflow.com/a/73590301) (and producing a non-working binary) only cuts down to 45 MB, which doesn't seem worth exploring further.

Suggesting the easy win for now.