### PR TITLE
Add vscode (debugger) launch config.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (win)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/win/bin/Debug/net10.0-windows/win-x64/MakeYourChoice.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/win",
+            "console": "internalConsole"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "win/make-your-choice.sln"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/win/MakeYourChoice.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoColor"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/win/MakeYourChoice.csproj",
+                "-c",
+                "Release",
+                "-r",
+                "win-x64",
+                "--self-contained",
+                "true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/win/MakeYourChoice.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/win/MakeYourChoice.csproj
+++ b/win/MakeYourChoice.csproj
@@ -6,8 +6,24 @@
         <UseWindowsForms>true</UseWindowsForms>
         <OutputType>WinExe</OutputType>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
+        <Platforms>x64</Platforms>
+        <PlatformTarget>x64</PlatformTarget>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <!-- core single-file settings -->
+        <!-- auto-elevation and icon  -->
+        <ApplicationManifest>app.manifest</ApplicationManifest>
+        <ApplicationIcon>icon.ico</ApplicationIcon>
+
+        <!-- shared optimization settings -->
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
+        <EventSourceSupport>false</EventSourceSupport>
+        <DebuggerSupport Condition="'$(Configuration)' == 'Release'">false</DebuggerSupport>
+        <DebuggerSupport Condition="'$(Configuration)' == 'Debug'">true</DebuggerSupport>
+    </PropertyGroup>
+
+    <!-- core single-file settings (Release only) -->
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -17,18 +33,10 @@
         <!-- bundle _all_ content for self-extract at runtime -->
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
 
-        <!-- auto-elevation and icon  -->
-        <ApplicationManifest>app.manifest</ApplicationManifest>
-        <ApplicationIcon>icon.ico</ApplicationIcon>
-
         <!-- size optimization -->
         <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
         <PublishTrimmed>true</PublishTrimmed>
         <TrimMode>partial</TrimMode>
-        <InvariantGlobalization>true</InvariantGlobalization>
-        <DebuggerSupport>false</DebuggerSupport>
-        <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
-        <EventSourceSupport>false</EventSourceSupport>
         <_SuppressWinFormsTrimError>true</_SuppressWinFormsTrimError>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary
Adds "F5" VS Code launch configs to build the app in debug mode and launch it.

When VS Code is run as admin, debug build of MYC seems to be able to modify the hosts file successfully and correctly pauses at breakpoints in the IDE.

## Motivation
I need a debugger to figure out #11. Since I'm not a .NET developer, it took 30 minutes to set up. Might as well save someone else the trouble.

## Testing
`win.\build.ps1` successfully produces a release artifact of the right size that is able to modify the hosts file.